### PR TITLE
delegateUnwrap is nothrow

### DIFF
--- a/source/d2sqlite3/internal/memory.d
+++ b/source/d2sqlite3/internal/memory.d
@@ -39,7 +39,7 @@ void* delegateWrap(T)(T dlg, string name = null)
     return cast(void*) d;
 }
 
-WrappedDelegate!T* delegateUnwrap(T)(void* ptr)
+WrappedDelegate!T* delegateUnwrap(T)(void* ptr) nothrow
     if (isCallable!T)
 {
     return cast(WrappedDelegate!T*) ptr;


### PR DESCRIPTION
This fixes `nothrow` errors I received with LDC 1.6.0 (not with LDC 1.7.0).