### PR TITLE
PATCH: Respect CC environment variable in Makefile

### DIFF
--- a/sqlite3.mak
+++ b/sqlite3.mak
@@ -1,7 +1,8 @@
+CC?=	/usr/bin/cc
 all: sqlite3.o
 
 sqlite3.o: c/sqlite3.c
-	gcc -c -O2 -DSQLITE_ENABLE_COLUMN_METADATA -DSQLITE_ENABLE_UNLOCK_NOTIFY c/sqlite3.c
+	$(CC) -c -O2 -DSQLITE_ENABLE_COLUMN_METADATA -DSQLITE_ENABLE_UNLOCK_NOTIFY c/sqlite3.c
 
 clean:
 	rm -f *.o


### PR DESCRIPTION
The GNU C compiler does not by default come with every platform.
Hardcoding it makes the library extremely unportable. This checks
whether CC is declared in the environment. If so, it uses that. In any
other case it defaults to /usr/bin/cc which, on most Linux distros
defaults to GCC. On FreeBSD, which was the issue, it defaults to
clang.

Tested on:
```
[nico@triton ~]$ uname -apKU
FreeBSD triton.herrhotzenplotz.geek 13.0-CURRENT FreeBSD 13.0-CURRENT #0 r367174: Fri Oct 30 22:07:29 CET 2020     nico@triton.herrhotzenplotz.geek:/usr/obj/usr/src/amd64.amd64/sys/TRITON  amd64 amd64 1300124 1300124
```