### PR TITLE
Run the tests on `dub test`

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -27,3 +27,9 @@ configuration "ci" {
     sourceFiles "sqlite3.o" platform="posix"
     versions "SqliteEnableColumnMetadata" "SqliteEnableUnlockNotify"
 }
+
+configuration "unittest" {
+    // Make sure source/tests.d is included
+    systemDependencies "SQLite version >= 3.8.7"
+    libs "sqlite3"
+}


### PR DESCRIPTION
Due to DUB bug 2060 the 'with-lib' configuration was picked,
resulting in 'excludeSourceFiles' being applied and the test
were simply never run.
This was however not a problem on the CI, as we use a configuration
explicitly, but can bit a contributor that would just use `dub test`.