### PR TITLE
Allow to serialize aggregates to string if they have a `toString` method

### DIFF
--- a/source/d2sqlite3/internal/memory.d
+++ b/source/d2sqlite3/internal/memory.d
@@ -47,17 +47,19 @@ WrappedDelegate!T* delegateUnwrap(T)(void* ptr) nothrow
 
 // Anchors and returns a pointer to D memory, so that it will not
 // be moved or collected. For use with releaseMem.
-void* anchorMem(void* ptr)
+inout(void)* anchorMem(inout(void)* ptr)
 {
     GC.addRoot(ptr);
-    GC.setAttr(ptr, GC.BlkAttr.NO_MOVE);
+    // Cast to work around https://issues.dlang.org/show_bug.cgi?id=21484
+    GC.setAttr(cast(void*) ptr, GC.BlkAttr.NO_MOVE);
     return ptr;
 }
 
 // Passed to sqlite3_xxx_blob64/sqlite3_xxx_text64 to unanchor memory.
-extern(C) void releaseMem(void* ptr)
+extern(C) void releaseMem(const void* ptr)
 {
-    GC.setAttr(ptr, GC.BlkAttr.NO_MOVE);
+    // Cast to work around https://issues.dlang.org/show_bug.cgi?id=21484
+    GC.setAttr(cast(void*) ptr, GC.BlkAttr.NO_MOVE);
     GC.removeRoot(ptr);
 }
 

--- a/source/d2sqlite3/statement.d
+++ b/source/d2sqlite3/statement.d
@@ -182,10 +182,11 @@ public:
         else static if (isStaticArray!T)
             checkResult(sqlite3_bind_blob64(p.handle, index, cast(void*) value.ptr,
                                             value.sizeof, SQLITE_TRANSIENT));
-        else static if (isDynamicArray!T && !isSomeString!T)
+        else static if (isDynamicArray!T)
         {
-            auto arr = cast(void[]) value;
-            checkResult(sqlite3_bind_blob64(p.handle, index, anchorMem(arr.ptr), arr.length, &releaseMem));
+            const void[] arr = value;
+            checkResult(sqlite3_bind_blob64(p.handle, index, anchorMem(arr.ptr),
+                                            arr.length, &releaseMem));
         }
         else static if (is(T == Nullable!U, U...))
         {

--- a/source/tests.d
+++ b/source/tests.d
@@ -544,13 +544,9 @@ unittest // Injecting nullable
     statement = db.prepare("INSERT INTO test (i) VALUES (?)");
     statement.inject(Nullable!int.init);
 
-    auto results = db.execute("SELECT i FROM test ORDER BY rowid")
-        .map!(a => a.peek!(Nullable!int)(0))
-        .array;
-
-    assert(results.length == 2);
-    assert(results[0] == 1);
-    assert(results[1].isNull);
+    auto results = db.execute("SELECT i FROM test ORDER BY rowid");
+    assert(results.equal!((a, b) => a.peek!(Nullable!int)(0) == b)(
+               [ Nullable!int(1), Nullable!int.init ] ));
 }
 
 unittest // Injecting tuple

--- a/source/tests.d
+++ b/source/tests.d
@@ -3,6 +3,7 @@ module tests.d;
 version (unittest):
 
 import d2sqlite3;
+import std.algorithm;
 import std.exception : assertThrown, assertNotThrown;
 import std.string : format;
 import std.typecons : Nullable;
@@ -534,7 +535,6 @@ unittest // Iterable struct injecting
 
 unittest // Injecting nullable
 {
-    import std.algorithm : map;
     import std.array : array;
 
     auto db = Database(":memory:");
@@ -889,7 +889,6 @@ unittest // UTF-8
 
 unittest // loadExtension failure test
 {
-    import std.algorithm : canFind;
     import std.exception : collectExceptionMsg;
     auto db = Database(":memory:");
     auto msg = collectExceptionMsg(db.loadExtension("foobar"));


### PR DESCRIPTION
Deserialization not yet implemented, but it will follow the `fromString` approach Vibe.d uses.